### PR TITLE
Fix:alt attribute in img of trending movies

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,7 +105,7 @@ const App = () => {
               {trendingMovies.map((movie, index) => (
                 <li key={movie.$id}>
                   <p>{index + 1}</p>
-                  <img src={movie.poster_url} alt={movie.title} />
+                  <img src={movie.poster_url} alt={movie.searchTerm} />
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Problem
Alt attribute of the the img in trendingMovies wasn't getting populated

## Solution
Replace the {movie.title} with {movie.searchTerm}. searchTerm makes sense because this is what we are storing in the appwrite database and also this is the closest things to the movie title.

## Issue Reference
Closes #2 

![Arc_dBDl5Od6DO](https://github.com/user-attachments/assets/2c433363-8d52-4713-bfe6-69233437ec8c)
As you can see, alt is now visible